### PR TITLE
Check if addon singleton has already been added

### DIFF
--- a/addons/steam_devkit_notifier/plugin.gd
+++ b/addons/steam_devkit_notifier/plugin.gd
@@ -11,8 +11,8 @@ var has_loaded = false
 func _enter_tree() -> void:
 	if has_loaded:
 		return
-
-	add_autoload_singleton("DevkitMessenger", "devkit_messenger.gd")
+	if !ProjectSettings.has_setting("autoload/DevkitMessenger"):
+		add_autoload_singleton("DevkitMessenger", "devkit_messenger.gd")
 	add_control_to_dock(DOCK_SLOT_LEFT_BR, dock)
 	add_export_plugin(export_notifier_plugin)
 	has_loaded = true


### PR DESCRIPTION
This fixes a quite insignificant thing: 

Currently if you open a project with this plugin enabled, it'll be displayed as modified even if no changes has been made. It's because of add_autoload_plugin. The PR prevents that from happening.